### PR TITLE
Run inline when there's no TTY instead of failing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Tabbed TUI for running multiple CLI commands simultaneously. Built with Ink (React for terminals), TypeScript, Commander.
 
+## Scope
+
+This is for the commands you run **while you are actively developing** — a dev server, a queue listener, a watcher, a build in watch mode — for the length of a working session, with you sitting in front of it.
+
+It is not a CI runner and not a process supervisor. It works fine in CI (inline mode exits with a real code, `--json` is parseable) and nothing should gratuitously break there, but CI is not what the defaults are tuned for. Neither is unattended operation: there is no daemonising, no log rotation, no restart policy worth the name, and buffers are capped for memory rather than kept for later.
+
+Weigh proposals against the working session. "What if this runs for three days" and "what if nobody is watching" are usually the wrong questions here; "what happens when I save a file and something crashes" is the right one.
+
 ## Commands
 
 - `pnpm run build` — TypeScript compile to `dist/`
@@ -15,9 +23,11 @@ Always run build + test after changes.
 ## Architecture
 
 - `cli.tsx` — CLI entry point. Parses argv with Commander, then hands off to `multiplex()` and exits with its code. Validation errors from `multiplex()` are reported through `program.error`.
-- `multiplex.tsx` — the package's programmatic entry point (`main`/`exports`), exporting `multiplex(options)`. Validates options, sets up alternate screen, renders `<App>`, and resolves with an exit code once everything is torn down. All teardown funnels through a single `shutdown()`, wired to normal exit, render failure, and SIGINT/SIGTERM/SIGHUP/SIGQUIT.
+- `multiplex.tsx` — the package's programmatic entry point (`main`/`exports`), exporting `multiplex(options)`. Validates options, then runs either `runTui()` or `runInlineMode()`. Each has its own `shutdown()`, wired to normal exit, failure, and SIGINT/SIGTERM/SIGHUP/SIGQUIT via the shared `installTeardown`.
 - `app.tsx` — Main React/Ink component. Sidebar + content panes, keyboard input handling, search overlay, stream/tab mode toggle.
-- `use-processes.ts` — Hook that spawns/manages child processes. Handles stdout/stderr buffering, auto-restart with 5-attempt limit, desktop notifications on permanent failure.
+- `supervisor.ts` — The process layer, with no React and no rendering in it: spawn, line splitting, restart accounting, auto-restart with a 5-attempt limit, and settle detection. Emits events; both front ends drive it.
+- `use-processes.ts` — Thin React wrapper over the supervisor. Turns its events into the TUI's per-command buffers, stream lines, `failedProcs` state and desktop notifications.
+- `inline.ts` — The non-TUI front end. Same supervisor, but each line is written to stdout/stderr as it arrives, or serialised as NDJSON when `json` is set. Resolves with an exit code when everything has settled.
 - `use-scroll.ts` — Hook for scroll state (offset tracking, page up/down, new-output indicator).
 - `search.ts` — ANSI-aware search in two phases: `indexMatches` counts and locates matches across the whole buffer, `highlightLine` highlights a single line. Strips escape codes for matching, preserves them in output, highlights across ANSI boundaries.
 - `args.ts` — Command palette plus the two input paths onto `CommandDef[]`: `parseCommandDef` for CLI positionals (incremental, one value at a time) and `normalizeCommands` for programmatic input (validates and fills in colors for the whole list at once).
@@ -26,8 +36,16 @@ Always run build + test after changes.
 
 ## Design decisions
 
+- **A missing TTY is a fallback, not an error.** Piping, redirecting or running from CI drops to inline mode instead of refusing to start, because those are the cases where people most want a process runner. There is deliberately no flag to restore the old hard failure: it would only ever fire where nobody wanted a TUI anyway.
+- **The supervisor emits events, not formatted text.** It would have been shorter to keep building the `Process exited with code 1` strings where the exit is handled, but then JSON output would be a scrape of the human output and every renderer would inherit the TUI's wording. Each front end decides how an event reads.
+- **`onData` exists alongside `onLine` for one reason.** The tabbed view shows raw chunks so a partial line — a progress bar, a prompt — is visible before its newline lands. Everything line-oriented (the stream buffer, inline mode, JSON) uses `onLine` and waits for the newline. Dropping `onData` and rebuilding the tab buffer from lines would make unterminated output invisible until the process exits.
+- **Inline mode's defaults are not the TUI's**, in two places only: it exits when the last command does, and it exits with the first permanent failure's code. Everything else, auto-restart included, is identical — a mode-dependent default means the same command line behaves differently depending on whether someone piped it, which is worse than either choice.
+- **Restart is guarded by uptime, not by mode.** A crash inside `MIN_UPTIME_FOR_RESTART_MS` is never retried, because a command that died that fast never started; anything longer-lived gets the full 5 attempts. This is what replaced an earlier mode-dependent default, and it is why there is one `--no-restart` flag rather than a `--restart`/`--no-restart` pair plus a `getOptionValueSource` dance in `cli.tsx` to tell "not passed" from "passed false". `onFailed` carries a `FailureReason` so the distinction is visible rather than looking like a silently skipped restart.
+- **Only permanent failures set the exit code.** `onFailed`, not `onExit` — a command that crashed, auto-restarted and then ran clean did not fail the run.
+- **Multiplex's own notices go to stderr inline.** Command output goes to whichever stream it came from, so `multiplex ... > out.log` gets the commands' stdout and nothing else. This is why the supervisor tags every line with its stream, which the old merged `handleData` threw away.
+- **JSON events carry a `v`.** Anything parsing the stream needs to know when the shape changes; bumping `JSON_SCHEMA_VERSION` is the contract. `text` is ANSI-stripped, because a consumer parsing JSON does not want escape codes inside a string field.
 - **SIGKILL is intentional at all kill sites.** Exit and signal handlers are synchronous (can't wait for SIGTERM), manual restart spawns the replacement immediately (SIGTERM would race on port binding), and cleanup on unmount has no event loop to wait on. Do not change to SIGTERM.
-- **`restartingRef` counts outstanding intentional kills; only bump it when the kill lands.** It exists to stop our own SIGKILL being reported as a crash, and every entry must be paid for by a real exit event. Bumping it for a process that has already exited (or never spawned, so has no pid) leaves it set with no exit coming, which swallows the replacement's crash and leaves a dead process looking healthy in the sidebar — reachable by pressing `r` on a failed tab, the documented recovery path. Hence the `exitCode === null && signalCode === null` guard, and the bump sitting after `process.kill` inside the `try`. It is a count rather than a flag so two rapid restarts don't report the second kill as a crash.
+- **`intentionalKills` (in `supervisor.ts`) counts outstanding intentional kills; only bump it when the kill lands.** It exists to stop our own SIGKILL being reported as a crash, and every entry must be paid for by a real exit event. Bumping it for a process that has already exited (or never spawned, so has no pid) leaves it set with no exit coming, which swallows the replacement's crash and leaves a dead process looking healthy in the sidebar — reachable by pressing `r` on a failed tab, the documented recovery path. Hence the `exitCode === null && signalCode === null` guard, and the bump sitting after `process.kill` inside the `try`. It is a count rather than a flag so two rapid restarts don't report the second kill as a crash.
 - **Signal handlers are load-bearing, not belt-and-braces.** `process.on("exit")` does not run when the process is killed by a signal, and children are spawned into their own process groups so they never receive the terminal's SIGHUP. Without explicit SIGINT/SIGTERM/SIGHUP/SIGQUIT handlers, closing the terminal window leaves every dev server running and holding its port.
 - **`shutdown()` ordering is fixed:** unmount Ink → kill children → leave the alternate screen → flush output. Ink's final frame and its raw-mode teardown have to happen while we still own the alternate screen; the flush has to happen after we've left it, or the logs never reach real scrollback. It guards on `shuttingDown`, so a second signal mid-flush force-exits rather than printing twice.
 - **`multiplex()` never calls `process.exit` on its own.** It returns an exit code and removes the signal and exit listeners it installed, so a host process that calls it programmatically survives and keeps a usable terminal. Only the signal handlers exit, because a signal has to terminate the process.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A tabbed TUI for running multiple commands simultaneously with searchable, scrol
 
 When you exit, the interleaved output is flushed to your terminal scrollback so you don't lose your logs, up to the `--stream-buffer-size` limit.
 
+Without an interactive terminal — piped, redirected, or in CI — it runs [inline](#inline-mode) instead: same labelled, interleaved output, printed as it arrives, with no TUI.
+
 ## Install
 
 ```bash
@@ -19,7 +21,7 @@ npx @laravel/multiplex 'server,php artisan serve' 'queue,php artisan queue:liste
 ## Requirements
 
 - **Node 22.13 or later.**
-- **An interactive terminal.** Both stdin and stdout must be a TTY. Piping or redirecting either one (`multiplex ... | tee log`) exits with an error instead of starting your commands, as does running it from CI.
+- **An interactive terminal, for the TUI.** Both stdin and stdout must be a TTY. Without one, multiplex runs in [inline mode](#inline-mode) instead of failing.
 - **Non-interactive commands.** Child processes are spawned without stdin, so anything that prompts for input — `php artisan tinker`, a migration confirmation — won't work.
 - **A stable terminal width.** Children are told how wide they are via `COLUMNS` when they start, and that can't be updated afterwards. Resizing the terminal leaves already-running commands sizing their output to the old width; press `r` to restart one against the new width.
 
@@ -67,10 +69,59 @@ multiplex --no-restart 'build,pnpm run build'
 | `--title <name>` | Set the terminal tab title | |
 | `--cwd <path>` | Set the working directory (must exist) | Current directory |
 | `-s, --stream` | Start in stream mode (interleaved output) | `false` |
+| `-i, --inline` | Print output inline instead of rendering the TUI | On when not a TTY |
+| `--json` | Emit newline-delimited JSON events. Implies `--inline` | `false` |
 | `--timestamps` | Display timestamps on each output line | `false` |
 | `--no-restart` | Disable auto-restart on crash | |
 | `--buffer-size <lines>` | Max lines kept per command buffer | `2000` |
 | `--stream-buffer-size <lines>` | Max lines kept in stream buffer | `10000` |
+
+## Inline Mode
+
+Inline mode is multiplex without the TUI: no alternate screen, no keyboard handling, no tabs or search. Every line is written straight to your terminal as it arrives, prefixed with the command's colored label — the same interleaved format the TUI flushes to scrollback when you quit. Your existing scrollback is left alone, output scrolls normally, and `Ctrl-C` still tears down the whole process tree.
+
+It's used automatically whenever stdin or stdout isn't a TTY, so `multiplex ... | tee log`, `make dev` and CI jobs all work. Use `-i` to ask for it in a real terminal.
+
+A few things behave differently from the TUI, because the TUI's defaults are wrong for a pipeline:
+
+- **The run ends when the last command does.** The TUI stays open showing dead tabs; inline mode exits.
+- **The exit code reflects your commands.** The first command to fail permanently sets the exit code; if none do, it's `0`. The TUI always exits `0`.
+- **stderr stays on stderr.** Command output goes to the stream it came from, and multiplex's own notices ("Process exited with code 1") always go to stderr, so a redirected stdout holds nothing but your commands' output.
+- **Color follows the usual rules** — on when stdout is a TTY, forced by `FORCE_COLOR`, disabled by `NO_COLOR`.
+
+```bash
+multiplex -i 'build,pnpm run build' 'test,pnpm test'
+multiplex 'lint,pnpm lint' 'types,tsc --noEmit' | tee ci.log
+```
+
+### JSON Output
+
+`--json` writes newline-delimited JSON to stdout, one object per event, instead of formatted lines. It implies `--inline`. Nothing else is written to stdout, so the stream is safe to pipe into `jq`.
+
+```bash
+multiplex --json 'build,pnpm run build' 'test,pnpm test' | jq -c 'select(.type == "failed")'
+```
+
+```json
+{"v":1,"time":"2026-01-01T12:00:00.000Z","type":"start","label":"build","command":"pnpm run build","pid":4123}
+{"v":1,"time":"2026-01-01T12:00:00.412Z","type":"output","label":"build","stream":"stdout","text":"compiled in 320ms"}
+{"v":1,"time":"2026-01-01T12:00:01.900Z","type":"exit","label":"test","code":1,"signal":null}
+{"v":1,"time":"2026-01-01T12:00:01.901Z","type":"restarting","label":"test","attempt":1,"max":5}
+{"v":1,"time":"2026-01-01T12:00:06.100Z","type":"failed","label":"test","code":1}
+{"v":1,"time":"2026-01-01T12:00:06.101Z","type":"done","code":1}
+```
+
+`reason` on a `failed` event is one of `spawn-error`, `crashed-immediately`, `attempts-exhausted` or `restart-disabled`. Every event carries `v` (the schema version, currently `1`) and an ISO-8601 `time`. `text` has ANSI escape codes stripped. A `start` event is emitted for each restart as well as the first spawn, and `done` is always the last line.
+
+| `type` | Fields | Meaning |
+| --- | --- | --- |
+| `start` | `label`, `command`, `pid` | A command was spawned |
+| `output` | `label`, `stream`, `text` | One line of output, from `stdout` or `stderr` |
+| `exit` | `label`, `code`, `signal` | A command exited |
+| `restarting` | `label`, `attempt`, `max` | An auto-restart was scheduled |
+| `error` | `label`, `message` | The command could not be spawned |
+| `failed` | `label`, `code`, `reason` | A command failed for good; no more restarts |
+| `done` | `code` | Every command has stopped; the process exit code |
 
 ## Programmatic API
 
@@ -92,7 +143,9 @@ process.exit(code);
 
 Every `command` is run through `sh -c`, so it is a shell string, not an argv array — pipes, redirects and `&&` all work. That also means **you must never build a `command` out of untrusted input.** Anything that reaches the string is executed with the privileges of the calling process, so a value taken from a config file, a request payload or a workspace manifest is a remote code execution vector. If the commands are not written by you, quote every interpolated value yourself before passing it in.
 
-`multiplex()` takes over the terminal for the duration of the call: it enters the alternate screen, installs its own `SIGINT`/`SIGTERM`/`SIGHUP`/`SIGQUIT` handlers, and renders the TUI. It resolves with the same exit code the CLI would have used — `0` normally, `1` if rendering failed. By then the terminal is restored, every child process is dead, the buffered output has been flushed to scrollback, and the signal handlers it installed have been removed, so the calling process is free to carry on. The same requirements apply as for the CLI: both stdin and stdout must be a TTY.
+`multiplex()` takes over the terminal for the duration of the call: it enters the alternate screen, installs its own `SIGINT`/`SIGTERM`/`SIGHUP`/`SIGQUIT` handlers, and renders the TUI. It resolves with the same exit code the CLI would have used — `0` normally, `1` if rendering failed. By then the terminal is restored, every child process is dead, the buffered output has been flushed to scrollback, and the signal handlers it installed have been removed, so the calling process is free to carry on.
+
+If stdin or stdout isn't a TTY it runs [inline](#inline-mode) instead, resolving with the first failing command's exit code. Set `inline: true` to ask for that in a real terminal.
 
 Options are validated before anything is written to the terminal, so an invalid option throws with the screen untouched.
 
@@ -101,6 +154,8 @@ Options are validated before anything is written to the terminal, so an invalid 
 | `commands` | `{ label, command, color? }[]` | Required, at least one. `color` is an optional 6-digit hex value | |
 | `title` | `string` | Set the terminal tab title | |
 | `cwd` | `string` | Set the working directory (must exist) | `process.cwd()` |
+| `inline` | `boolean` | Print output inline instead of rendering the TUI | On when not a TTY |
+| `json` | `boolean` | Emit newline-delimited JSON events on stdout. Implies inline | `false` |
 | `stream` | `boolean` | Start in stream mode (interleaved output) | `false` |
 | `timestamps` | `boolean` | Display timestamps on each output line | `false` |
 | `restart` | `boolean` | Auto-restart on crash | `true` |
@@ -111,11 +166,13 @@ Commands that omit a color are assigned one from the built-in palette (also expo
 
 ## Auto-Restart
 
-Processes that crash (exit with a non-zero code) are automatically restarted after a 1-second delay. A process is restarted up to 5 times; on the 6th consecutive failure it stops restarting and is marked as failed in the sidebar. A manual restart with `r` resets the counter.
+Processes that crash (exit with a non-zero code) are automatically restarted after a 1-second delay, up to 5 times; on the 6th consecutive failure they stop restarting and are marked as failed. A manual restart with `r` resets the counter. This is the same in the TUI and inline.
+
+**A command that dies within a second of starting is not retried at all.** Something that fails that fast never got off the ground — a typo, a port already bound, a missing binary — and retrying only scrolls the real error out of view while you fix it. A command that was up for longer was working until it wasn't, which is the case auto-restart exists for.
 
 A desktop notification is sent when a process permanently fails (macOS via `osascript`, Linux via `notify-send` if available).
 
-Use `--no-restart` to disable auto-restart for one-shot commands like builds or migrations.
+Use `--no-restart` to turn it off entirely, for one-shot commands like builds or migrations.
 
 ## Keyboard Shortcuts
 
@@ -154,6 +211,8 @@ Use `--no-restart` to disable auto-restart for one-shot commands like builds or 
 
 ## Features
 
+- **Inline mode** when there's no TTY, so pipes and CI get labelled output and a real exit code instead of an error
+- **JSON output** as newline-delimited events, for anything that needs to parse a run
 - **Tabbed view** with a sidebar showing all running commands
 - **Stream mode** for interleaved output with colored labels, with per-command filtering
 - **Search** with ANSI-aware highlighting across output

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,7 +6,7 @@ import type { CommandDef, OutputRef, ProcsRef } from "./types.js";
 import { useProcesses } from "./use-processes.js";
 import { useScroll } from "./use-scroll.js";
 import {
-    hexToRgb,
+    formatStreamLabel,
     MIN_TABS_LAYOUT_WIDTH,
     minTabsLayoutHeight,
     sidebarWidth,
@@ -559,10 +559,8 @@ export function App({
             .filter((sl) => !hiddenProcs.has(sl.cmdIndex))
             .map((sl) => {
                 const cmd = commandDefs[sl.cmdIndex];
-                const [r, g, b] = hexToRgb(cmd.color);
-                const padding = " ".repeat(maxLabelLen - cmd.label.length);
 
-                return `${sl.ts}\x1b[1;38;2;${r};${g};${b}m${padding}${cmd.label}\x1b[0m\x1b[90m │ \x1b[0m${sl.text}`;
+                return `${sl.ts}${formatStreamLabel(cmd.label, cmd.color, maxLabelLen, true)}${sl.text}`;
             });
     }, [
         renderTick,

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -14,6 +14,16 @@ const program = new Command()
     .option("--cwd <path>", "Set the working directory", process.cwd())
     .option("-s, --stream", "Start in stream mode", false)
     .option(
+        "-i, --inline",
+        "Print output inline instead of rendering the TUI (the default when not a TTY)",
+        false,
+    )
+    .option(
+        "--json",
+        "Emit newline-delimited JSON events. Implies --inline",
+        false,
+    )
+    .option(
         "--buffer-size <lines>",
         "Set the max lines per command buffer",
         parsePositiveInt,
@@ -88,6 +98,8 @@ const program = new Command()
 const opts = program.opts<{
     cwd: string;
     stream: boolean;
+    inline: boolean;
+    json: boolean;
     bufferSize: number;
     streamBufferSize: number;
     timestamps: boolean;
@@ -100,6 +112,8 @@ try {
     const code = await multiplex({
         commands,
         cwd: opts.cwd,
+        inline: opts.inline,
+        json: opts.json,
         stream: opts.stream,
         bufferSize: opts.bufferSize,
         streamBufferSize: opts.streamBufferSize,

--- a/src/inline.test.ts
+++ b/src/inline.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const tsx = fileURLToPath(new URL("../node_modules/.bin/tsx", import.meta.url));
+const cli = fileURLToPath(new URL("./cli.tsx", import.meta.url));
+
+// stdio is piped, so none of these are a TTY and every run takes the inline
+// path — which is the point: this is what a pipe, a Makefile or CI actually get.
+function runCli(
+    args: string[],
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+        const proc = spawn(tsx, [cli, ...args], {
+            stdio: ["ignore", "pipe", "pipe"],
+            env: { ...process.env, NO_COLOR: "1" },
+        });
+
+        let stdout = "";
+        let stderr = "";
+
+        proc.stdout.on("data", (d) => {
+            stdout += d;
+        });
+        proc.stderr.on("data", (d) => {
+            stderr += d;
+        });
+        proc.on("error", reject);
+        proc.on("close", (code) => resolve({ code, stdout, stderr }));
+    });
+}
+
+describe("inline mode", () => {
+    it("runs instead of erroring when stdout is not a TTY", async () => {
+        const { code, stdout } = await runCli([
+            "web,echo hello",
+            "api,echo world",
+        ]);
+
+        assert.equal(code, 0);
+        assert.match(stdout, /web │ hello/);
+        assert.match(stdout, /api │ world/);
+    });
+
+    it("keeps command output on stdout and its own notices on stderr", async () => {
+        const { stdout, stderr } = await runCli(["a,echo out; echo err >&2"]);
+
+        assert.match(stdout, /a │ out/);
+        assert.match(stderr, /a │ err/);
+        assert.doesNotMatch(stdout, /exited with code/);
+        assert.match(stderr, /Process exited with code 0/);
+    });
+
+    it("exits nonzero when a command fails", async () => {
+        const { code } = await runCli(["ok,true", "bad,exit 3"]);
+
+        assert.equal(code, 3);
+    });
+
+    it("exits zero when every command succeeds", async () => {
+        const { code } = await runCli(["a,true", "b,true"]);
+
+        assert.equal(code, 0);
+    });
+
+    it("does not retry a command that crashes immediately", async () => {
+        const { stderr } = await runCli(["a,exit 1"]);
+
+        assert.doesNotMatch(stderr, /Restarting/);
+    });
+
+    it("does not retry at all with --no-restart", async () => {
+        const { stderr } = await runCli([
+            "--no-restart",
+            "a,sleep 1.2; exit 1",
+        ]);
+
+        assert.doesNotMatch(stderr, /Restarting/);
+    });
+
+    it("emits one JSON event per line, with ANSI stripped", async () => {
+        const { code, stdout } = await runCli([
+            "--json",
+            "a,printf '\\033[31mred\\033[0m\\n'; exit 2",
+        ]);
+
+        const events = stdout
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+
+        assert.equal(code, 2);
+        assert.deepEqual(
+            events.map((e) => e.type),
+            ["start", "output", "exit", "failed", "done"],
+        );
+        assert.equal(events.at(-2).reason, "crashed-immediately");
+        assert.equal(events[1].text, "red");
+        assert.equal(events[1].stream, "stdout");
+        assert.equal(events.at(-1).code, 2);
+        assert.ok(events.every((e) => e.v === 1 && typeof e.time === "string"));
+    });
+
+    it("accepts --inline even though it is already implied", async () => {
+        const { code, stdout } = await runCli(["-i", "a,echo hello"]);
+
+        assert.equal(code, 0);
+        assert.match(stdout, /a │ hello/);
+    });
+});

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -1,0 +1,247 @@
+import { stripAnsi } from "./search.js";
+import { createSupervisor, type Supervisor } from "./supervisor.js";
+import type { CommandDef, ProcsRef } from "./types.js";
+import { formatStreamLabel, formatTimestamp } from "./util.js";
+
+const JSON_SCHEMA_VERSION = 1;
+
+export type InlineOptions = {
+    commandDefs: CommandDef[];
+    cwd: string;
+    timestamps: boolean;
+    autoRestart: boolean;
+    json: boolean;
+    color: boolean;
+    columns: number;
+    procsRef?: ProcsRef;
+};
+
+export type InlineRun = {
+    supervisor: Supervisor;
+    /** Resolves with the exit code once every command has stopped for good. */
+    done: Promise<number>;
+};
+
+function write(stream: NodeJS.WriteStream, text: string) {
+    try {
+        stream.write(text);
+    } catch {
+        // The other end of the pipe can close before we are finished.
+    }
+}
+
+/**
+ * Runs the commands without taking over the terminal: no alternate screen, no
+ * Ink, no input handling — every line is written to stdout (or stderr) the
+ * moment it arrives, and the run ends when the last command does.
+ */
+export function runInline({
+    commandDefs,
+    cwd,
+    timestamps,
+    autoRestart,
+    json,
+    color,
+    columns,
+    procsRef,
+}: InlineOptions): InlineRun {
+    const maxLabelLen = Math.max(...commandDefs.map((c) => c.label.length));
+
+    let resolveDone: (code: number) => void = () => {};
+    let settled = false;
+    // Only permanent failures count. A command that crashed, auto-restarted and
+    // then ran clean did not fail the run.
+    let failureCode: number | null = null;
+
+    const done = new Promise<number>((resolve) => {
+        resolveDone = resolve;
+    });
+
+    const emit = (event: Record<string, unknown>, time: Date) => {
+        write(
+            process.stdout,
+            `${JSON.stringify({ v: JSON_SCHEMA_VERSION, time: time.toISOString(), ...event })}\n`,
+        );
+    };
+
+    const label = (index: number) =>
+        formatStreamLabel(
+            commandDefs[index].label,
+            commandDefs[index].color,
+            maxLabelLen,
+            color,
+        );
+
+    const printLine = (
+        index: number,
+        text: string,
+        time: Date,
+        stream: NodeJS.WriteStream,
+    ) => {
+        const ts = timestamps ? formatTimestamp(time) : "";
+
+        write(stream, `${ts}${label(index)}${text}\n`);
+    };
+
+    // Multiplex's own notices are diagnostics, so they go to stderr and leave a
+    // redirected stdout holding nothing but the commands' own output.
+    const printSystem = (index: number, text: string, time: Date) => {
+        printLine(
+            index,
+            color ? `\x1b[2m\x1b[3m${text}\x1b[0m` : text,
+            time,
+            process.stderr,
+        );
+    };
+
+    const finish = (time: Date) => {
+        if (settled) {
+            return;
+        }
+
+        settled = true;
+
+        const code = failureCode ?? 0;
+
+        if (json) {
+            emit({ type: "done", code }, time);
+        }
+
+        resolveDone(code);
+    };
+
+    const supervisor = createSupervisor({
+        commandDefs,
+        cwd,
+        columns,
+        autoRestart,
+        forceColor: color,
+        handlers: {
+            onSpawn({ index, pid, time }) {
+                if (json) {
+                    emit(
+                        {
+                            type: "start",
+                            label: commandDefs[index].label,
+                            command: commandDefs[index].command,
+                            pid,
+                        },
+                        time,
+                    );
+                }
+            },
+
+            onLine({ index, text, stream, time }) {
+                if (json) {
+                    emit(
+                        {
+                            type: "output",
+                            label: commandDefs[index].label,
+                            stream,
+                            text: stripAnsi(text),
+                        },
+                        time,
+                    );
+
+                    return;
+                }
+
+                printLine(
+                    index,
+                    text,
+                    time,
+                    stream === "stderr" ? process.stderr : process.stdout,
+                );
+            },
+
+            onSpawnError({ index, message, time }) {
+                if (json) {
+                    emit(
+                        {
+                            type: "error",
+                            label: commandDefs[index].label,
+                            message,
+                        },
+                        time,
+                    );
+
+                    return;
+                }
+
+                printSystem(index, `Failed to start: ${message}`, time);
+            },
+
+            onExit({ index, code, signal, time }) {
+                if (json) {
+                    emit(
+                        {
+                            type: "exit",
+                            label: commandDefs[index].label,
+                            code,
+                            signal,
+                        },
+                        time,
+                    );
+
+                    return;
+                }
+
+                printSystem(
+                    index,
+                    signal
+                        ? `Process killed by ${signal}`
+                        : `Process exited with code ${code}`,
+                    time,
+                );
+            },
+
+            onRestartScheduled({ index, attempt, max, time }) {
+                if (json) {
+                    emit(
+                        {
+                            type: "restarting",
+                            label: commandDefs[index].label,
+                            attempt,
+                            max,
+                        },
+                        time,
+                    );
+
+                    return;
+                }
+
+                printSystem(index, `Restarting (${attempt}/${max})...`, time);
+            },
+
+            onFailed({ index, code, reason, time }) {
+                if (failureCode === null) {
+                    failureCode = code === null || code === 0 ? 1 : code;
+                }
+
+                if (json) {
+                    emit(
+                        {
+                            type: "failed",
+                            label: commandDefs[index].label,
+                            code,
+                            reason,
+                        },
+                        time,
+                    );
+                }
+            },
+
+            onSettled({ time }) {
+                finish(time);
+            },
+        },
+    });
+
+    supervisor.start();
+
+    if (procsRef) {
+        procsRef.current = supervisor.procs;
+    }
+
+    return { supervisor, done };
+}

--- a/src/multiplex.tsx
+++ b/src/multiplex.tsx
@@ -4,8 +4,14 @@ import { resolve } from "node:path";
 import { render } from "ink";
 import { App } from "./app.js";
 import { normalizeCommands } from "./args.js";
+import { runInline } from "./inline.js";
 import type { MultiplexOptions, OutputRef, ProcsRef } from "./types.js";
-import { hexToRgb, MIN_ROWS, sanitizeTitle } from "./util.js";
+import {
+    formatStreamLabel,
+    inlineChildColumns,
+    MIN_ROWS,
+    sanitizeTitle,
+} from "./util.js";
 
 export { DEFAULT_COLORS } from "./args.js";
 export type { CommandInput, MultiplexOptions } from "./types.js";
@@ -20,10 +26,56 @@ function positiveInt(value: number, name: string): number {
     return value;
 }
 
+function supportsColor(): boolean {
+    if (process.env.NO_COLOR) {
+        return false;
+    }
+
+    if (process.env.FORCE_COLOR && process.env.FORCE_COLOR !== "0") {
+        return true;
+    }
+
+    return Boolean(process.stdout.isTTY);
+}
+
 /**
- * Runs the TUI and resolves with an exit code once it has exited, the terminal
- * is restored and every child process is gone. Options are validated before we
- * touch the terminal, so a bad option throws with the screen untouched.
+ * Installs the teardown that has to survive a signal. `process.on("exit")` does
+ * not run when we are killed by one, and the children sit in their own process
+ * groups so they never see the terminal's own SIGHUP — without these, closing
+ * the window leaves every dev server running and holding its port.
+ */
+function installTeardown(shutdown: () => void, onExit: () => void) {
+    const handlers = SIGNALS.map((signal) => {
+        const handler = () => {
+            shutdown();
+            process.exit(128 + constants.signals[signal]);
+        };
+
+        process.on(signal, handler);
+
+        return [signal, handler] as const;
+    });
+
+    process.on("exit", onExit);
+
+    return () => {
+        for (const [signal, handler] of handlers) {
+            process.removeListener(signal, handler);
+        }
+
+        process.removeListener("exit", onExit);
+    };
+}
+
+/**
+ * Runs the commands and resolves with an exit code once everything has exited,
+ * the terminal is restored and every child process is gone. Options are
+ * validated before we touch the terminal, so a bad option throws with the screen
+ * untouched.
+ *
+ * Renders the TUI when the terminal can support it and falls back to inline
+ * output — every line printed as it arrives, no alternate screen, no input —
+ * when it cannot, so a pipe or a CI job gets usable output rather than an error.
  */
 export async function multiplex(options: MultiplexOptions): Promise<number> {
     const commandDefs = normalizeCommands(options.commands ?? []);
@@ -34,22 +86,9 @@ export async function multiplex(options: MultiplexOptions): Promise<number> {
     );
     const timestamps = options.timestamps ?? false;
     const title = options.title ? sanitizeTitle(options.title) : undefined;
-
-    if (!process.stdin.isTTY || !process.stdout.isTTY) {
-        const stream = process.stdin.isTTY ? "stdout" : "stdin";
-
-        throw new Error(
-            `multiplex needs an interactive terminal, but ${stream} is not a TTY. Run it directly rather than through a pipe or redirect.`,
-        );
-    }
-
-    const rows = process.stdout.rows ?? 0;
-
-    if (rows < MIN_ROWS) {
-        throw new Error(
-            `multiplex needs at least ${MIN_ROWS} terminal rows, but this terminal has ${rows}. Make the window taller and try again.`,
-        );
-    }
+    const json = options.json ?? false;
+    const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY);
+    const inline = json || (options.inline ?? false) || !interactive;
 
     const cwd = resolve(options.cwd ?? process.cwd());
 
@@ -61,17 +100,12 @@ export async function multiplex(options: MultiplexOptions): Promise<number> {
         throw new Error(`cwd path is not a directory: ${cwd}`);
     }
 
-    const outputRef: OutputRef = { current: [] };
     const procsRef: ProcsRef = { current: [] };
-
-    let instance: ReturnType<typeof render> | undefined;
-    let shuttingDown = false;
-    let titlePushed = false;
 
     function killAll() {
         for (const proc of procsRef.current) {
             try {
-                if (proc.pid) {
+                if (proc?.pid) {
                     process.kill(-proc.pid, "SIGKILL");
                 }
             } catch {
@@ -80,129 +114,184 @@ export async function multiplex(options: MultiplexOptions): Promise<number> {
         }
     }
 
-    function restoreTerminal() {
-        try {
-            process.stdout.write("\x1b[?25h\x1b[?1049l");
+    return inline ? runInlineMode() : runTui();
 
-            // Guarded: restoreTerminal runs twice, and a second pop would take someone else's title off the stack.
-            if (titlePushed) {
-                titlePushed = false;
+    async function runInlineMode(): Promise<number> {
+        const color = !json && supportsColor();
+        const useTitle = title && !json && process.stdout.isTTY;
 
-                process.stdout.write("\x1b[23;0t");
+        let shuttingDown = false;
+
+        function shutdown() {
+            if (shuttingDown) {
+                return;
             }
-        } catch {
-            //
-        }
-    }
 
-    function flushOutput() {
-        if (outputRef.current.length === 0) {
-            return;
-        }
+            shuttingDown = true;
 
-        const maxLabelLen = Math.max(...commandDefs.map((c) => c.label.length));
+            killAll();
 
-        try {
-            for (const sl of outputRef.current) {
-                const cmd = commandDefs[sl.cmdIndex];
-                const [r, g, b] = hexToRgb(cmd.color);
-                const padding = " ".repeat(maxLabelLen - cmd.label.length);
-
-                process.stdout.write(
-                    `${sl.ts}\x1b[1;38;2;${r};${g};${b}m[${cmd.label}]${padding} \x1b[0m${sl.text}\n`,
-                );
+            if (useTitle) {
+                try {
+                    process.stdout.write("\x1b[23;0t");
+                } catch {
+                    //
+                }
             }
-        } catch {
-            // The terminal can already be gone when we got here via SIGHUP.
-        }
-    }
-
-    /**
-     * Unmount first, so Ink's final frame and its raw-mode teardown happen while
-     * we still own the alternate screen, then leave the screen before flushing so
-     * the logs land in the real scrollback.
-     */
-    function shutdown() {
-        if (shuttingDown) {
-            return;
         }
 
-        shuttingDown = true;
+        const uninstall = installTeardown(shutdown, killAll);
+
+        if (useTitle) {
+            process.stdout.write(`\x1b[22;0t\x1b]0;${title}\x07`);
+        }
 
         try {
-            instance?.unmount();
-        } catch {
-            //
-        }
+            const { done } = runInline({
+                commandDefs,
+                cwd,
+                timestamps,
+                autoRestart: options.restart ?? true,
+                json,
+                color,
+                columns: inlineChildColumns(
+                    commandDefs.map((c) => c.label),
+                    process.stdout.columns ?? 80,
+                    timestamps,
+                ),
+                procsRef,
+            });
 
-        killAll();
-        restoreTerminal();
-        flushOutput();
-    }
+            const code = await done;
 
-    // Signals terminate the process without running exit handlers, and the
-    // children sit in their own process groups so they never see the terminal's
-    // own SIGHUP. Without these, closing the terminal window leaves every dev
-    // server running and holding its port. A second signal mid-flush hits the
-    // shuttingDown guard and force-exits rather than printing twice.
-    const signalHandlers = SIGNALS.map((signal) => {
-        const handler = () => {
             shutdown();
-            process.exit(128 + constants.signals[signal]);
-        };
 
-        process.on(signal, handler);
+            return code;
+        } catch {
+            shutdown();
 
-        return [signal, handler] as const;
-    });
-
-    // Last resort for exits we did not route through shutdown().
-    const exitHandler = () => {
-        killAll();
-        restoreTerminal();
-    };
-
-    process.on("exit", exitHandler);
-
-    if (title) {
-        process.stdout.write(`\x1b[22;0t\x1b]0;${title}\x07`);
-
-        titlePushed = true;
+            return 1;
+        } finally {
+            uninstall();
+        }
     }
 
-    process.stdout.write("\x1b[?1049h\x1b[?25l");
+    async function runTui(): Promise<number> {
+        const rows = process.stdout.rows ?? 0;
 
-    try {
-        instance = render(
-            <App
-                commandDefs={commandDefs}
-                cwd={cwd}
-                initialStreamMode={options.stream ?? false}
-                bufferSize={bufferSize}
-                streamBufferSize={streamBufferSize}
-                timestamps={timestamps}
-                autoRestart={options.restart ?? true}
-                title={title}
-                outputRef={outputRef}
-                procsRef={procsRef}
-            />,
-            { exitOnCtrlC: true },
-        );
-
-        await instance.waitUntilExit();
-
-        shutdown();
-
-        return 0;
-    } catch {
-        shutdown();
-
-        return 1;
-    } finally {
-        for (const [signal, handler] of signalHandlers) {
-            process.removeListener(signal, handler);
+        if (rows < MIN_ROWS) {
+            throw new Error(
+                `multiplex needs at least ${MIN_ROWS} terminal rows, but this terminal has ${rows}. Make the window taller and try again.`,
+            );
         }
 
-        process.removeListener("exit", exitHandler);
+        const outputRef: OutputRef = { current: [] };
+
+        let instance: ReturnType<typeof render> | undefined;
+        let shuttingDown = false;
+        let titlePushed = false;
+
+        function restoreTerminal() {
+            try {
+                process.stdout.write("\x1b[?25h\x1b[?1049l");
+
+                // Guarded: restoreTerminal runs twice, and a second pop would take someone else's title off the stack.
+                if (titlePushed) {
+                    titlePushed = false;
+
+                    process.stdout.write("\x1b[23;0t");
+                }
+            } catch {
+                //
+            }
+        }
+
+        function flushOutput() {
+            if (outputRef.current.length === 0) {
+                return;
+            }
+
+            const maxLabelLen = Math.max(
+                ...commandDefs.map((c) => c.label.length),
+            );
+
+            try {
+                for (const sl of outputRef.current) {
+                    const cmd = commandDefs[sl.cmdIndex];
+
+                    process.stdout.write(
+                        `${sl.ts}${formatStreamLabel(cmd.label, cmd.color, maxLabelLen, true)}${sl.text}\n`,
+                    );
+                }
+            } catch {
+                // The terminal can already be gone when we got here via SIGHUP.
+            }
+        }
+
+        /**
+         * Unmount first, so Ink's final frame and its raw-mode teardown happen
+         * while we still own the alternate screen, then leave the screen before
+         * flushing so the logs land in the real scrollback.
+         */
+        function shutdown() {
+            if (shuttingDown) {
+                return;
+            }
+
+            shuttingDown = true;
+
+            try {
+                instance?.unmount();
+            } catch {
+                //
+            }
+
+            killAll();
+            restoreTerminal();
+            flushOutput();
+        }
+
+        const uninstall = installTeardown(shutdown, () => {
+            killAll();
+            restoreTerminal();
+        });
+
+        if (title) {
+            process.stdout.write(`\x1b[22;0t\x1b]0;${title}\x07`);
+
+            titlePushed = true;
+        }
+
+        process.stdout.write("\x1b[?1049h\x1b[?25l");
+
+        try {
+            instance = render(
+                <App
+                    commandDefs={commandDefs}
+                    cwd={cwd}
+                    initialStreamMode={options.stream ?? false}
+                    bufferSize={bufferSize}
+                    streamBufferSize={streamBufferSize}
+                    timestamps={timestamps}
+                    autoRestart={options.restart ?? true}
+                    title={title}
+                    outputRef={outputRef}
+                    procsRef={procsRef}
+                />,
+                { exitOnCtrlC: true },
+            );
+
+            await instance.waitUntilExit();
+
+            shutdown();
+
+            return 0;
+        } catch {
+            shutdown();
+
+            return 1;
+        } finally {
+            uninstall();
+        }
     }
 }

--- a/src/supervisor.test.ts
+++ b/src/supervisor.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+    createSupervisor,
+    type FailureReason,
+    type OutputStream,
+} from "./supervisor.js";
+import type { CommandDef } from "./types.js";
+
+type Line = { label: string; text: string; stream: OutputStream };
+
+type RunResult = {
+    lines: Line[];
+    exits: { label: string; code: number | null }[];
+    failures: { label: string; code: number | null; reason: FailureReason }[];
+    restarts: number;
+};
+
+// Retry timings are compressed so the exhaustion path costs a fraction of a
+// second instead of the ~12s the real 1s uptime guard and 1s delay would need.
+const FAST = { minUptimeMs: 50, restartDelayMs: 10, maxRestarts: 5 };
+
+function run(
+    commandDefs: CommandDef[],
+    { autoRestart = false, fast = false } = {},
+): Promise<RunResult> {
+    return new Promise((resolve, reject) => {
+        const result: RunResult = {
+            lines: [],
+            exits: [],
+            failures: [],
+            restarts: 0,
+        };
+
+        const timer = setTimeout(() => {
+            supervisor.stop();
+            reject(new Error("supervisor never settled"));
+        }, 15_000);
+
+        const supervisor = createSupervisor({
+            commandDefs,
+            cwd: process.cwd(),
+            columns: 80,
+            autoRestart,
+            forceColor: false,
+            ...(fast ? FAST : {}),
+            handlers: {
+                onLine({ index, text, stream }) {
+                    result.lines.push({
+                        label: commandDefs[index].label,
+                        text,
+                        stream,
+                    });
+                },
+                onExit({ index, code }) {
+                    result.exits.push({
+                        label: commandDefs[index].label,
+                        code,
+                    });
+                },
+                onFailed({ index, code, reason }) {
+                    result.failures.push({
+                        label: commandDefs[index].label,
+                        code,
+                        reason,
+                    });
+                },
+                onRestartScheduled() {
+                    result.restarts++;
+                },
+                onSettled() {
+                    clearTimeout(timer);
+                    supervisor.stop();
+                    resolve(result);
+                },
+            },
+        });
+
+        supervisor.start();
+    });
+}
+
+const cmd = (label: string, command: string): CommandDef => ({
+    label,
+    color: "#93c5fd",
+    command,
+});
+
+describe("createSupervisor", () => {
+    it("emits every line of output and settles once all commands exit", async () => {
+        const result = await run([
+            cmd("a", "printf 'one\\ntwo\\n'"),
+            cmd("b", "printf 'three\\n'"),
+        ]);
+
+        assert.deepEqual(
+            result.lines.map((l) => `${l.label}:${l.text}`).sort(),
+            ["a:one", "a:two", "b:three"],
+        );
+        assert.equal(result.exits.length, 2);
+        assert.equal(result.failures.length, 0);
+    });
+
+    it("tags stdout and stderr separately", async () => {
+        const result = await run([
+            cmd("a", "echo out; echo err >&2; echo out2"),
+        ]);
+
+        assert.deepEqual(result.lines.map((l) => [l.stream, l.text]).sort(), [
+            ["stderr", "err"],
+            ["stdout", "out"],
+            ["stdout", "out2"],
+        ]);
+    });
+
+    // Without this the last line of anything that does not end in a newline —
+    // an unterminated error message, a prompt — is lost when the process dies.
+    it("flushes a trailing partial line before the exit", async () => {
+        const result = await run([cmd("a", "printf 'no newline'")]);
+
+        assert.deepEqual(
+            result.lines.map((l) => l.text),
+            ["no newline"],
+        );
+    });
+
+    it("reports a nonzero exit as a permanent failure when not restarting", async () => {
+        const result = await run([cmd("a", "exit 3")]);
+
+        assert.deepEqual(result.exits, [{ label: "a", code: 3 }]);
+        assert.deepEqual(result.failures, [
+            { label: "a", code: 3, reason: "restart-disabled" },
+        ]);
+    });
+
+    it("does not report a clean exit as a failure", async () => {
+        const result = await run([cmd("a", "true")]);
+
+        assert.deepEqual(result.failures, []);
+    });
+
+    // The whole point of the uptime guard: a command that never got off the
+    // ground is not going to be fixed by trying it four more times.
+    it("does not retry a command that crashes immediately", async () => {
+        const result = await run([cmd("a", "exit 1")], { autoRestart: true });
+
+        assert.equal(result.restarts, 0);
+        assert.equal(result.exits.length, 1);
+        assert.deepEqual(result.failures, [
+            { label: "a", code: 1, reason: "crashed-immediately" },
+        ]);
+    });
+
+    it("retries a command that stayed up first, then gives up after five", async () => {
+        const result = await run([cmd("a", "sleep 0.2; exit 1")], {
+            autoRestart: true,
+            fast: true,
+        });
+
+        assert.equal(result.restarts, 5);
+        assert.equal(result.exits.length, 6);
+        assert.deepEqual(result.failures, [
+            { label: "a", code: 1, reason: "attempts-exhausted" },
+        ]);
+    });
+
+    it("splits lines across chunk boundaries", async () => {
+        const result = await run([
+            cmd("a", "printf 'start'; sleep 0.2; printf 'end\\nnext\\n'"),
+        ]);
+
+        assert.deepEqual(
+            result.lines.map((l) => l.text),
+            ["startend", "next"],
+        );
+    });
+});

--- a/src/supervisor.ts
+++ b/src/supervisor.ts
@@ -1,0 +1,385 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import type { CommandDef } from "./types.js";
+
+export const MAX_AUTO_RESTARTS = 5;
+
+export const RESTART_DELAY_MS = 1000;
+
+/**
+ * How long a command has to have been up for a crash to be worth retrying.
+ * Something that dies this fast never got off the ground — a typo, a port
+ * already bound, a missing binary — and trying again five times just scrolls the
+ * real error out of view while you fix it. Anything that ran for longer was
+ * working until it wasn't, which is exactly the case auto-restart is for.
+ */
+export const MIN_UPTIME_FOR_RESTART_MS = 1000;
+
+/** Why a command is not going to be restarted. */
+export type FailureReason =
+    | "spawn-error"
+    | "crashed-immediately"
+    | "attempts-exhausted"
+    | "restart-disabled";
+
+export type OutputStream = "stdout" | "stderr";
+
+/**
+ * Everything the supervisor knows how to report. It deliberately emits events
+ * rather than formatted text: the TUI renders these as dim lines in a buffer,
+ * inline mode prints them, and JSON mode serialises them. Baking the wording in
+ * here would make the machine-readable output a scrape of the human one.
+ */
+export type SupervisorHandlers = {
+    onSpawn?(e: { index: number; pid?: number; time: Date }): void;
+    /**
+     * A raw chunk, carriage returns stripped, before it has been split into
+     * lines. The tabbed view renders it so a partial line — a progress bar, a
+     * prompt — shows up before its newline arrives; anything line-oriented
+     * should use onLine instead.
+     */
+    onData?(e: {
+        index: number;
+        chunk: string;
+        stream: OutputStream;
+        time: Date;
+    }): void;
+    onLine?(e: {
+        index: number;
+        text: string;
+        stream: OutputStream;
+        time: Date;
+    }): void;
+    onSpawnError?(e: { index: number; message: string; time: Date }): void;
+    onExit?(e: {
+        index: number;
+        code: number | null;
+        signal: NodeJS.Signals | null;
+        time: Date;
+    }): void;
+    onRestartScheduled?(e: {
+        index: number;
+        attempt: number;
+        max: number;
+        time: Date;
+    }): void;
+    onRestarted?(e: { index: number; manual: boolean; time: Date }): void;
+    onFailed?(e: {
+        index: number;
+        code: number | null;
+        reason: FailureReason;
+        time: Date;
+    }): void;
+    /** Every command has stopped and none is waiting to be restarted. */
+    onSettled?(e: { time: Date }): void;
+};
+
+export type SupervisorOptions = {
+    commandDefs: CommandDef[];
+    cwd: string;
+    /** Advertised to children as COLUMNS. They read it once, at spawn. */
+    columns: number;
+    autoRestart: boolean;
+    forceColor: boolean;
+    /** Overridable so tests can exercise the retry paths without real seconds. */
+    minUptimeMs?: number;
+    restartDelayMs?: number;
+    maxRestarts?: number;
+    handlers?: SupervisorHandlers;
+};
+
+export type Supervisor = {
+    /** Mutable so a React caller can swap in fresh closures without respawning. */
+    handlers: SupervisorHandlers;
+    readonly procs: ChildProcess[];
+    /** Last exit code seen per command; null if killed by a signal or still running. */
+    readonly exitCodes: (number | null)[];
+    start(): void;
+    restart(index: number, manual?: boolean): void;
+    killAll(): void;
+    stop(): void;
+};
+
+export function createSupervisor({
+    commandDefs,
+    cwd,
+    columns,
+    autoRestart,
+    forceColor,
+    minUptimeMs = MIN_UPTIME_FOR_RESTART_MS,
+    restartDelayMs = RESTART_DELAY_MS,
+    maxRestarts = MAX_AUTO_RESTARTS,
+    handlers = {},
+}: SupervisorOptions): Supervisor {
+    const procs: ChildProcess[] = [];
+    const exitCodes: (number | null)[] = commandDefs.map(() => null);
+    const partials: string[] = commandDefs.map(() => "");
+    const running: boolean[] = commandDefs.map(() => false);
+    const autoRestartCounts: number[] = commandDefs.map(() => 0);
+    const spawnedAt: number[] = commandDefs.map(() => 0);
+    const pendingRestarts = new Set<number>();
+    const restartTimers = new Map<number, ReturnType<typeof setTimeout>>();
+    // How many exits per command are ours rather than the process failing. A
+    // plain flag was wrong in both directions: set with no exit coming, it
+    // swallowed the next real crash, and it could not hold two rapid restarts.
+    const intentionalKills = new Map<number, number>();
+
+    let stopped = false;
+
+    const supervisor: Supervisor = {
+        handlers,
+        procs,
+        exitCodes,
+        start,
+        restart,
+        killAll,
+        stop,
+    };
+
+    function checkSettled(time: Date) {
+        if (stopped || running.some(Boolean) || pendingRestarts.size > 0) {
+            return;
+        }
+
+        supervisor.handlers.onSettled?.({ time });
+    }
+
+    function spawnProcess(cmd: CommandDef, i: number): ChildProcess {
+        const env: NodeJS.ProcessEnv = {
+            ...process.env,
+            COLUMNS: String(columns),
+        };
+
+        if (forceColor) {
+            env.FORCE_COLOR = "1";
+        }
+
+        const proc = spawn("sh", ["-c", cmd.command], {
+            cwd,
+            detached: true,
+            env,
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+
+        const spawnTime = new Date();
+
+        running[i] = true;
+        exitCodes[i] = null;
+        spawnedAt[i] = spawnTime.getTime();
+
+        supervisor.handlers.onSpawn?.({
+            index: i,
+            pid: proc.pid,
+            time: spawnTime,
+        });
+
+        const handleData = (stream: OutputStream) => (data: Buffer) => {
+            const time = new Date();
+            const chunk = data.toString().replace(/\r/g, "");
+
+            supervisor.handlers.onData?.({ index: i, chunk, stream, time });
+
+            partials[i] += chunk;
+
+            const lines = partials[i].split("\n");
+
+            partials[i] = lines.pop() ?? "";
+
+            for (const text of lines) {
+                supervisor.handlers.onLine?.({ index: i, text, stream, time });
+            }
+        };
+
+        proc.stdout?.on("data", handleData("stdout"));
+        proc.stderr?.on("data", handleData("stderr"));
+
+        proc.on("error", (err) => {
+            const time = new Date();
+
+            supervisor.handlers.onSpawnError?.({
+                index: i,
+                message: err.message,
+                time,
+            });
+
+            // 'error' is not guaranteed to be followed by 'exit', so settle the
+            // command here or a failed spawn hangs inline mode forever.
+            if (running[i]) {
+                running[i] = false;
+
+                supervisor.handlers.onFailed?.({
+                    index: i,
+                    code: null,
+                    reason: "spawn-error",
+                    time,
+                });
+
+                checkSettled(time);
+            }
+        });
+
+        proc.on("exit", (code, signal) => {
+            const ours = intentionalKills.get(i) ?? 0;
+
+            if (ours > 0) {
+                intentionalKills.set(i, ours - 1);
+
+                return;
+            }
+
+            if (!running[i]) {
+                return;
+            }
+
+            running[i] = false;
+            exitCodes[i] = code;
+
+            const time = new Date();
+
+            if (partials[i].trim()) {
+                supervisor.handlers.onLine?.({
+                    index: i,
+                    text: partials[i],
+                    stream: "stdout",
+                    time,
+                });
+            }
+
+            partials[i] = "";
+
+            supervisor.handlers.onExit?.({ index: i, code, signal, time });
+
+            if (code === 0 || code === null) {
+                autoRestartCounts[i] = 0;
+
+                checkSettled(time);
+
+                return;
+            }
+
+            autoRestartCounts[i]++;
+
+            const uptime = time.getTime() - spawnedAt[i];
+            const reason: FailureReason | null = !autoRestart
+                ? "restart-disabled"
+                : uptime < minUptimeMs
+                  ? "crashed-immediately"
+                  : autoRestartCounts[i] > maxRestarts
+                    ? "attempts-exhausted"
+                    : null;
+
+            if (reason) {
+                supervisor.handlers.onFailed?.({
+                    index: i,
+                    code,
+                    reason,
+                    time,
+                });
+
+                checkSettled(time);
+
+                return;
+            }
+
+            supervisor.handlers.onRestartScheduled?.({
+                index: i,
+                attempt: autoRestartCounts[i],
+                max: maxRestarts,
+                time,
+            });
+
+            pendingRestarts.add(i);
+
+            restartTimers.set(
+                i,
+                setTimeout(() => {
+                    restartTimers.delete(i);
+                    pendingRestarts.delete(i);
+                    restart(i, false);
+                }, restartDelayMs),
+            );
+        });
+
+        return proc;
+    }
+
+    function start() {
+        commandDefs.forEach((cmd, i) => {
+            procs[i] = spawnProcess(cmd, i);
+        });
+    }
+
+    function restart(index: number, manual = true) {
+        if (stopped) {
+            return;
+        }
+
+        const timer = restartTimers.get(index);
+
+        if (timer) {
+            clearTimeout(timer);
+            restartTimers.delete(index);
+            pendingRestarts.delete(index);
+        }
+
+        if (manual) {
+            autoRestartCounts[index] = 0;
+
+            const proc = procs[index];
+
+            // Only claim an exit when the kill is what causes it. Restarting a
+            // process that already died — the whole point of `r` on a failed
+            // tab — sends no signal and produces no exit event, so claiming one
+            // here would swallow the replacement's crash and leave a dead
+            // process looking healthy.
+            if (
+                proc?.pid &&
+                proc.exitCode === null &&
+                proc.signalCode === null
+            ) {
+                try {
+                    process.kill(-proc.pid, "SIGKILL");
+
+                    intentionalKills.set(
+                        index,
+                        (intentionalKills.get(index) ?? 0) + 1,
+                    );
+                } catch {
+                    //
+                }
+            }
+        }
+
+        running[index] = false;
+        partials[index] = "";
+
+        supervisor.handlers.onRestarted?.({ index, manual, time: new Date() });
+
+        procs[index] = spawnProcess(commandDefs[index], index);
+    }
+
+    function killAll() {
+        for (const proc of procs) {
+            try {
+                if (proc?.pid) {
+                    process.kill(-proc.pid, "SIGKILL");
+                }
+            } catch {
+                //
+            }
+        }
+    }
+
+    function stop() {
+        stopped = true;
+
+        for (const timer of restartTimers.values()) {
+            clearTimeout(timer);
+        }
+
+        restartTimers.clear();
+        pendingRestarts.clear();
+        killAll();
+    }
+
+    return supervisor;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,13 @@ export type CommandInput = {
 export type MultiplexOptions = {
     commands: CommandInput[];
     cwd?: string;
+    /**
+     * Print output inline instead of rendering the TUI. Already the behaviour
+     * when stdin or stdout is not a TTY; this asks for it in a real terminal.
+     */
+    inline?: boolean;
+    /** NDJSON on stdout, one object per event. Implies inline. */
+    json?: boolean;
     stream?: boolean;
     timestamps?: boolean;
     restart?: boolean;

--- a/src/use-processes.ts
+++ b/src/use-processes.ts
@@ -1,5 +1,6 @@
-import { type ChildProcess, execSync, spawn } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createSupervisor, type Supervisor } from "./supervisor.js";
 import type { CommandDef, OutputRef, ProcsRef, StreamLine } from "./types.js";
 import { childColumns, formatTimestamp, systemMsg } from "./util.js";
 
@@ -70,328 +71,198 @@ export function useProcesses({
     const outputBuffersRef = useRef<string[]>(commandDefs.map(() => ""));
     const outputLineCountsRef = useRef<number[]>(commandDefs.map(() => 1));
     const streamLinesRef = useRef<StreamLine[]>([]);
-    const partialsRef = useRef<string[]>(commandDefs.map(() => ""));
-    const procsRef = useRef<ChildProcess[]>([]);
-    // How many exits per command are ours rather than the process failing. A
-    // plain flag was wrong in both directions: set with no exit coming, it
-    // swallowed the next real crash, and it could not hold two rapid restarts.
-    const restartingRef = useRef<Map<number, number>>(new Map());
     const spawnTimeRef = useRef<number[]>(commandDefs.map(() => 0));
     const pendingRestartsRef = useRef<Set<number>>(new Set());
-    const autoRestartTimersRef = useRef<
-        Map<number, ReturnType<typeof setTimeout>>
-    >(new Map());
-    const autoRestartCountsRef = useRef<number[]>(commandDefs.map(() => 0));
-    const restartProcessRef = useRef<(i: number, manual?: boolean) => void>(
-        () => {},
-    );
+    const supervisorRef = useRef<Supervisor | null>(null);
     const [failedProcs, setFailedProcs] = useState<Set<number>>(new Set());
 
     if (outputRef) {
         outputRef.current = streamLinesRef.current;
     }
 
-    const spawnProcess = useCallback(
-        (cmd: CommandDef, i: number) => {
-            spawnTimeRef.current[i] = Date.now();
+    const pushLine = useCallback(
+        (index: number, text: string, time: Date) => {
+            const ts = timestamps ? formatTimestamp(time) : "";
 
-            const proc = spawn("sh", ["-c", cmd.command], {
-                cwd,
-                detached: true,
-                env: {
-                    ...process.env,
-                    FORCE_COLOR: "1",
-                    COLUMNS: String(
-                        childColumns(
-                            commandDefs.map((c) => c.label),
-                            stdout?.columns ?? 80,
-                            timestamps,
-                        ),
-                    ),
-                },
-                stdio: ["ignore", "pipe", "pipe"],
-            });
+            if (timestamps) {
+                outputBuffersRef.current[index] += `${ts}${text}\n`;
+            }
 
-            const handleData = (data: Buffer) => {
-                const text = data.toString().replace(/\r/g, "");
+            streamLinesRef.current.push({ cmdIndex: index, text, ts });
 
-                if (!timestamps) {
-                    outputBuffersRef.current[i] += text;
-                }
-
-                let newLines = 0;
-
-                for (let c = 0; c < text.length; c++) {
-                    if (text[c] === "\n") {
-                        newLines++;
-                    }
-                }
-
-                outputLineCountsRef.current[i] += newLines;
-
-                if (outputLineCountsRef.current[i] > bufferSize * 1.5) {
-                    const bufLines = outputBuffersRef.current[i].split("\n");
-                    outputBuffersRef.current[i] = bufLines
-                        .slice(-bufferSize)
-                        .join("\n");
-                    outputLineCountsRef.current[i] = bufferSize;
-                }
-
-                partialsRef.current[i] += text;
-
-                const lines = partialsRef.current[i].split("\n");
-
-                partialsRef.current[i] = lines.pop() ?? "";
-
-                const now = new Date();
-                const tsPrefix = timestamps ? formatTimestamp(now) : "";
-
-                for (const line of lines) {
-                    streamLinesRef.current.push({
-                        cmdIndex: i,
-                        text: line,
-                        ts: tsPrefix,
-                    });
-
-                    if (timestamps) {
-                        outputBuffersRef.current[i] += `${tsPrefix}${line}\n`;
-                    }
-                }
-
-                if (streamLinesRef.current.length > streamBufferSize * 1.5) {
-                    streamLinesRef.current.splice(
-                        0,
-                        streamLinesRef.current.length - streamBufferSize,
-                    );
-                }
-
-                triggerRender();
-            };
-
-            proc.stdout?.on("data", handleData);
-            proc.stderr?.on("data", handleData);
-
-            proc.on("error", (err) => {
-                const now = new Date();
-                const errorMsg = systemMsg(`Failed to start: ${err.message}`);
-                const tsPrefix = timestamps ? formatTimestamp(now) : "";
-
-                outputBuffersRef.current[i] += `\n${tsPrefix}${errorMsg}`;
-                streamLinesRef.current.push({
-                    cmdIndex: i,
-                    text: errorMsg,
-                    ts: tsPrefix,
-                });
-
-                setFailedProcs((prev) => new Set(prev).add(i));
-                triggerRender();
-            });
-
-            proc.on("exit", (exitCode) => {
-                const weKilledIt = restartingRef.current.get(i) ?? 0;
-
-                if (weKilledIt > 0) {
-                    restartingRef.current.set(i, weKilledIt - 1);
-
-                    return;
-                }
-
-                const now = new Date();
-                const exitMsg = systemMsg(
-                    `Process exited with code ${exitCode}`,
+            if (streamLinesRef.current.length > streamBufferSize * 1.5) {
+                streamLinesRef.current.splice(
+                    0,
+                    streamLinesRef.current.length - streamBufferSize,
                 );
-                const tsPrefix = timestamps ? formatTimestamp(now) : "";
+            }
+        },
+        [timestamps, streamBufferSize],
+    );
 
-                outputBuffersRef.current[i] += `\n${tsPrefix}${exitMsg}`;
-                streamLinesRef.current.push({
-                    cmdIndex: i,
-                    text: exitMsg,
-                    ts: tsPrefix,
-                });
+    // A system message is not process output, so it never carries a timestamp
+    // prefix in the buffer the way a real line does.
+    const pushSystem = useCallback(
+        (index: number, text: string, time: Date) => {
+            const msg = systemMsg(text);
+            const ts = timestamps ? formatTimestamp(time) : "";
 
-                if (partialsRef.current[i].trim()) {
+            outputBuffersRef.current[index] += `\n${ts}${msg}`;
+            outputLineCountsRef.current[index]++;
+
+            streamLinesRef.current.push({ cmdIndex: index, text: msg, ts });
+        },
+        [timestamps],
+    );
+
+    if (!supervisorRef.current) {
+        supervisorRef.current = createSupervisor({
+            commandDefs,
+            cwd,
+            columns: childColumns(
+                commandDefs.map((c) => c.label),
+                stdout?.columns ?? 80,
+                timestamps,
+            ),
+            autoRestart,
+            forceColor: true,
+            handlers: {
+                onSpawn({ index, time }) {
+                    spawnTimeRef.current[index] = time.getTime();
+                },
+
+                onData({ index, chunk }) {
+                    if (!timestamps) {
+                        outputBuffersRef.current[index] += chunk;
+                    }
+
+                    let newLines = 0;
+
+                    for (let c = 0; c < chunk.length; c++) {
+                        if (chunk[c] === "\n") {
+                            newLines++;
+                        }
+                    }
+
+                    outputLineCountsRef.current[index] += newLines;
+
+                    if (outputLineCountsRef.current[index] > bufferSize * 1.5) {
+                        const bufLines =
+                            outputBuffersRef.current[index].split("\n");
+
+                        outputBuffersRef.current[index] = bufLines
+                            .slice(-bufferSize)
+                            .join("\n");
+                        outputLineCountsRef.current[index] = bufferSize;
+                    }
+
+                    triggerRender();
+                },
+
+                onLine({ index, text, time }) {
+                    pushLine(index, text, time);
+                },
+
+                onSpawnError({ index, message, time }) {
+                    pushSystem(index, `Failed to start: ${message}`, time);
+                    triggerRender();
+                },
+
+                onExit({ index, code, time }) {
+                    pushSystem(index, `Process exited with code ${code}`, time);
+                    triggerRender();
+                },
+
+                onRestartScheduled({ index, attempt, max, time }) {
+                    pendingRestartsRef.current.add(index);
+                    pushSystem(
+                        index,
+                        `Restarting (${attempt}/${max})...`,
+                        time,
+                    );
+                    triggerRender();
+                },
+
+                onRestarted({ index, time }) {
+                    pendingRestartsRef.current.delete(index);
+
+                    const msg = systemMsg(
+                        timestamps
+                            ? "Restarted"
+                            : `Restarted at ${time.toLocaleTimeString("en-GB")}`,
+                    );
+                    const ts = timestamps ? formatTimestamp(time) : "";
+
+                    outputBuffersRef.current[index] = `${ts}${msg}\n`;
+                    outputLineCountsRef.current[index] = 2;
+
                     streamLinesRef.current.push({
-                        cmdIndex: i,
-                        text: partialsRef.current[i],
-                        ts: tsPrefix,
+                        cmdIndex: index,
+                        text: msg,
+                        ts,
                     });
-                    partialsRef.current[i] = "";
-                }
 
-                if (exitCode === 0 || exitCode === null) {
-                    autoRestartCountsRef.current[i] = 0;
-                } else {
-                    autoRestartCountsRef.current[i]++;
+                    setFailedProcs((prev) => {
+                        const next = new Set(prev);
 
-                    if (autoRestart && autoRestartCountsRef.current[i] <= 5) {
-                        const attempt = autoRestartCountsRef.current[i];
-                        const restartMsg = systemMsg(
-                            `Restarting (${attempt}/5)...`,
-                        );
-                        const restartTsPrefix = timestamps
-                            ? formatTimestamp(now)
-                            : "";
+                        next.delete(index);
 
-                        outputBuffersRef.current[i] +=
-                            `\n${restartTsPrefix}${restartMsg}`;
-                        streamLinesRef.current.push({
-                            cmdIndex: i,
-                            text: restartMsg,
-                            ts: restartTsPrefix,
-                        });
+                        return next;
+                    });
 
-                        pendingRestartsRef.current.add(i);
+                    triggerRender();
+                },
 
-                        const timer = setTimeout(() => {
-                            autoRestartTimersRef.current.delete(i);
-                            pendingRestartsRef.current.delete(i);
-                            restartProcessRef.current(i, false);
-                        }, 1000);
+                onFailed({ index, code }) {
+                    setFailedProcs((prev) => new Set(prev).add(index));
 
-                        autoRestartTimersRef.current.set(i, timer);
-                    } else {
-                        setFailedProcs((prev) => new Set(prev).add(i));
+                    if (code !== null) {
                         notify(
                             title ?? "Multiplex",
-                            `${cmd.label} crashed (exit code ${exitCode})`,
+                            `${commandDefs[index].label} crashed (exit code ${code})`,
                         );
                     }
-                }
 
-                triggerRender();
-            });
+                    triggerRender();
+                },
+            },
+        });
+    }
 
-            return proc;
-        },
-        [
-            autoRestart,
-            cwd,
-            bufferSize,
-            streamBufferSize,
-            timestamps,
-            triggerRender,
-        ],
-    );
-
-    const restartProcess = useCallback(
-        (i: number, manual = true) => {
-            const pendingTimer = autoRestartTimersRef.current.get(i);
-            if (pendingTimer) {
-                clearTimeout(pendingTimer);
-                autoRestartTimersRef.current.delete(i);
-                pendingRestartsRef.current.delete(i);
-            }
-
-            if (manual) {
-                autoRestartCountsRef.current[i] = 0;
-
-                const proc = procsRef.current[i];
-
-                // Only claim an exit when the kill is what causes it. Restarting
-                // a process that already died — the whole point of `r` on a
-                // failed tab — sends no signal and produces no exit event, so
-                // claiming one here would swallow the replacement's crash and
-                // leave a dead process looking healthy.
-                if (
-                    proc?.pid &&
-                    proc.exitCode === null &&
-                    proc.signalCode === null
-                ) {
-                    try {
-                        process.kill(-proc.pid, "SIGKILL");
-                        restartingRef.current.set(
-                            i,
-                            (restartingRef.current.get(i) ?? 0) + 1,
-                        );
-                    } catch {
-                        //
-                    }
-                }
-            }
-
-            const now = new Date();
-            const restartMsg = timestamps
-                ? systemMsg("Restarted")
-                : systemMsg(`Restarted at ${now.toLocaleTimeString("en-GB")}`);
-            const tsPrefix = timestamps ? formatTimestamp(now) : "";
-
-            outputBuffersRef.current[i] = `${tsPrefix}${restartMsg}\n`;
-            outputLineCountsRef.current[i] = 2;
-            partialsRef.current[i] = "";
-
-            streamLinesRef.current.push({
-                cmdIndex: i,
-                text: restartMsg,
-                ts: tsPrefix,
-            });
-
-            setFailedProcs((prev) => {
-                const next = new Set(prev);
-
-                next.delete(i);
-
-                return next;
-            });
-
-            const newProc = spawnProcess(commandDefs[i], i);
-
-            procsRef.current[i] = newProc;
-
-            if (externalProcsRef) {
-                externalProcsRef.current[i] = newProc;
-            }
-
-            triggerRender();
-        },
-        [commandDefs, spawnProcess, triggerRender],
-    );
-
-    restartProcessRef.current = restartProcess;
+    const restartProcess = useCallback((index: number) => {
+        supervisorRef.current?.restart(index, true);
+    }, []);
 
     useEffect(() => {
-        const procs = commandDefs.map((cmd, i) => spawnProcess(cmd, i));
+        const supervisor = supervisorRef.current;
 
-        procsRef.current = procs;
-
-        if (externalProcsRef) {
-            externalProcsRef.current = procs;
+        if (!supervisor) {
+            return;
         }
 
-        return () => {
-            for (const timer of autoRestartTimersRef.current.values()) {
-                clearTimeout(timer);
-            }
+        supervisor.start();
 
-            autoRestartTimersRef.current.clear();
+        if (externalProcsRef) {
+            externalProcsRef.current = supervisor.procs;
+        }
 
-            procs.forEach((proc) => {
-                try {
-                    if (proc.pid) {
-                        process.kill(-proc.pid, "SIGKILL");
-                    }
-                } catch {
-                    //
-                }
-            });
-        };
-    }, [commandDefs, spawnProcess]);
+        return () => supervisor.stop();
+    }, []);
 
     const clearOutput = useCallback(
         (index: number) => {
             const now = new Date();
-            const clearMsg = timestamps
-                ? systemMsg("Cleared")
-                : systemMsg(`Cleared at ${now.toLocaleTimeString("en-GB")}`);
-            const tsPrefix = timestamps ? formatTimestamp(now) : "";
+            const msg = systemMsg(
+                timestamps
+                    ? "Cleared"
+                    : `Cleared at ${now.toLocaleTimeString("en-GB")}`,
+            );
+            const ts = timestamps ? formatTimestamp(now) : "";
 
-            outputBuffersRef.current[index] = `${tsPrefix}${clearMsg}`;
+            outputBuffersRef.current[index] = `${ts}${msg}`;
             outputLineCountsRef.current[index] = 1;
 
-            streamLinesRef.current.push({
-                cmdIndex: index,
-                text: clearMsg,
-                ts: tsPrefix,
-            });
+            streamLinesRef.current.push({ cmdIndex: index, text: msg, ts });
         },
         [timestamps],
     );

--- a/src/util.ts
+++ b/src/util.ts
@@ -95,3 +95,42 @@ export function childColumns(
 
     return Math.max(MIN_CHILD_COLUMNS, Math.min(tabbed, stream));
 }
+
+/**
+ * The label prefix in front of every interleaved line. The only implementation:
+ * the stream pane, the flush on exit and inline mode all call it, so the same
+ * run cannot come out looking like two different programs depending on where you
+ * happened to read it. Its width is STREAM_LABEL_EXTRA past the longest label.
+ */
+export function formatStreamLabel(
+    label: string,
+    color: string,
+    maxLabelLen: number,
+    useColor: boolean,
+): string {
+    const padding = " ".repeat(maxLabelLen - label.length);
+
+    if (!useColor) {
+        return `${padding}${label} │ `;
+    }
+
+    const [r, g, b] = hexToRgb(color);
+
+    return `\x1b[1;38;2;${r};${g};${b}m${padding}${label}\x1b[0m\x1b[90m │ \x1b[0m`;
+}
+
+/**
+ * COLUMNS for inline mode. There is no pane to truncate against, so this only
+ * stops children wrapping under their own label prefix.
+ */
+export function inlineChildColumns(
+    labels: string[],
+    totalColumns: number,
+    timestamps: boolean,
+): number {
+    const maxLabelLen = Math.max(...labels.map((l) => l.length));
+    const prefix =
+        maxLabelLen + STREAM_LABEL_EXTRA + (timestamps ? TIMESTAMP_WIDTH : 0);
+
+    return Math.max(MIN_CHILD_COLUMNS, totalColumns - prefix);
+}


### PR DESCRIPTION
Right now multiplex just errors out if stdin or stdout isn't a TTY, so you can't pipe it or run it from a Makefile. Now it prints output inline instead: same labelled format as the stream pane, line by line in your normal terminal. Ctrl-C still kills everything. `-i` forces it, `--json` gets you newline-delimited events if you need to parse a run.

Most of the diff is moving the process handling out of the React hook into a supervisor both front ends can share. Fallout from that: stdout and stderr are tagged separately now instead of merged, and inline exits with the failing command's code.

One behavior change worth flagging. A command that dies within a second of starting no longer gets auto-restarted, since it never got off the ground and five retries just scroll the real error away.